### PR TITLE
Add force option to mailbox.put

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+- Add `force` option to `Mailbox`'s `put` method.
+
 ## 0.2.0
 
 - Lower SDK lower bound to 3.0.0.

--- a/lib/mailbox.dart
+++ b/lib/mailbox.dart
@@ -72,8 +72,14 @@ class Mailbox {
   void put(Uint8List message, {bool force = false}) {
     final buffer = message.isEmpty ? nullptr : _toBuffer(message);
     _mutex.runLocked(() {
-      if (!force && _mailbox.ref.state != _stateEmpty) {
-        throw StateError('Mailbox is full');
+      if (_mailbox.ref.state != _stateEmpty) {
+        if (!force) {
+          throw StateError('Mailbox is full');
+        }
+
+        if (_mailbox.ref.bufferLength > 0) {
+          malloc.free(_mailbox.ref.buffer);
+        }
       }
 
       _mailbox.ref.state = _stateFull;

--- a/lib/mailbox.dart
+++ b/lib/mailbox.dart
@@ -67,11 +67,12 @@ class Mailbox {
 
   /// Place a message into the mailbox if has space for it.
   ///
-  /// If mailbox already contains a message then [put] will throw.
-  void put(Uint8List message) {
+  /// If mailbox already contains a message then [put] will throw, unless
+  /// [force] is set to `true`.
+  void put(Uint8List message, {bool force = false}) {
     final buffer = message.isEmpty ? nullptr : _toBuffer(message);
     _mutex.runLocked(() {
-      if (_mailbox.ref.state != _stateEmpty) {
+      if (!force && _mailbox.ref.state != _stateEmpty) {
         throw StateError('Mailbox is full');
       }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: native_synchronization
 description: Low level synchronization primitives built on dart:ffi.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/dart-lang/native_synchronization
 
 environment:

--- a/test/mailbox_test.dart
+++ b/test/mailbox_test.dart
@@ -29,4 +29,14 @@ void main() {
     expect(value[41], equals(42));
     expect(await helperResult, equals('success'));
   });
+
+  test('mailbox throws', () {
+    final mailbox = Mailbox();
+    mailbox.put(Uint8List(42)..[41] = 42);
+    expect(() => mailbox.put(Uint8List(0)), throwsA(TypeMatcher<StateError>()));
+    mailbox.put(Uint8List(0), force: true);
+    final value = mailbox.take();
+    expect(value, isA<Uint8List>());
+    expect(value.length, equals(0));
+  });
 }


### PR DESCRIPTION
This PR adds an option to force overwrite the message already in `Mailbox`. This is necessary for dart-sass to properly shutdown. As dart-sass is being shutting down, we send a zero length message to the worker isolate to indicate that the main isolate is planning to shutdown, that no further work shall be done. Once the worker isolate received the message and detected that the length is zero, it will break out of the loop and stop the work, in order to prevent it from running another `mailbox.take` and getting stuck.

https://github.com/sass/dart-sass/blob/d4b19397c493adb6e518ed5344913aa2615c11f6/lib/src/embedded/reusable_isolate.dart#L119-L129

``` dart
  /// Shuts down the isolate.
  void kill() {
    _isolate.kill();
    _receivePort.close();

    // If the isolate is blocking on [Mailbox.take], it won't even process a
    // kill event, so we send an empty message to make sure it wakes up.
    try {
      _mailbox.put(Uint8List(0));
    } on StateError catch (_) {}
  }
```

This currently causes an issue that dart vm would lock up if sending of the empty message fails due to `Mailbox` already has content, and thus causes the worker isolate to not shutting down properly if it gets a non-empty message and quickly loop again to wait on the next message before the kill event is processed: https://github.com/sass/dart-sass/issues/2278

I've tested locally that this PR together with the following patch in dart-sass fixes the issue: https://github.com/sass/dart-sass/pull/2279

``` diff
diff --git a/lib/src/embedded/reusable_isolate.dart b/lib/src/embedded/reusable_isolate.dart
index 0ed9eec8..304cb3de 100644
--- a/lib/src/embedded/reusable_isolate.dart
+++ b/lib/src/embedded/reusable_isolate.dart
@@ -123,9 +123,7 @@ class ReusableIsolate {
 
     // If the isolate is blocking on [Mailbox.take], it won't even process a
     // kill event, so we send an empty message to make sure it wakes up.
-    try {
-      _mailbox.put(Uint8List(0));
-    } on StateError catch (_) {}
+    _mailbox.put(Uint8List(0), force: true);
   }
 }
 
```


