### PR TITLE
Add closed state to Mailbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+- Add a closed state to `Mailbox`.
+
 ## 0.2.0
 
 - Lower SDK lower bound to 3.0.0.

--- a/lib/mailbox.dart
+++ b/lib/mailbox.dart
@@ -47,6 +47,7 @@ class Mailbox {
 
   static const _stateEmpty = 0;
   static const _stateFull = 1;
+  static const _stateClosed = 2;
 
   static final finalizer = Finalizer((Pointer<_MailboxRepr> mailbox) {
     calloc.free(mailbox.ref.buffer);
@@ -72,7 +73,7 @@ class Mailbox {
     final buffer = message.isEmpty ? nullptr : _toBuffer(message);
     _mutex.runLocked(() {
       if (_mailbox.ref.state != _stateEmpty) {
-        throw StateError('Mailbox is full');
+        throw StateError('Mailbox is closed or full');
       }
 
       _mailbox.ref.state = _stateFull;
@@ -83,13 +84,32 @@ class Mailbox {
     });
   }
 
+  /// Close a mailbox.
+  ///
+  /// If mailbox already contains a message then it will be dropped.
+  void close() => _mutex.runLocked(() {
+        if (_mailbox.ref.state == _stateFull && _mailbox.ref.bufferLength > 0) {
+          malloc.free(_mailbox.ref.buffer);
+        }
+
+        _mailbox.ref.state = _stateClosed;
+        _mailbox.ref.buffer = nullptr;
+        _mailbox.ref.bufferLength = 0;
+
+        _condVar.notify();
+      });
+
   /// Take a message from the mailbox.
   ///
   /// If mailbox is empty this will synchronously block until message
   /// is available.
   Uint8List take() => _mutex.runLocked(() {
-        while (_mailbox.ref.state != _stateFull) {
+        while (_mailbox.ref.state == _stateEmpty) {
           _condVar.wait(_mutex);
+        }
+
+        if (_mailbox.ref.state == _stateClosed) {
+          throw StateError('Mailbox is closed');
         }
 
         final result = _toList(_mailbox.ref.buffer, _mailbox.ref.bufferLength);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: native_synchronization
 description: Low level synchronization primitives built on dart:ffi.
-version: 0.2.0
+version: 0.3.0
 repository: https://github.com/dart-lang/native_synchronization
 
 environment:

--- a/test/mailbox_test.dart
+++ b/test/mailbox_test.dart
@@ -29,4 +29,25 @@ void main() {
     expect(value[41], equals(42));
     expect(await helperResult, equals('success'));
   });
+
+  Future<String> startHelperIsolateClose(Sendable<Mailbox> sendableMailbox) {
+    return Isolate.run(() {
+      sleep(const Duration(milliseconds: 500));
+      final mailbox = sendableMailbox.materialize();
+      try {
+        mailbox.take();
+      } catch (_) {
+        return 'success';
+      }
+      return 'failed';
+    });
+  }
+
+  test('mailbox close', () async {
+    final mailbox = Mailbox();
+    mailbox.put(Uint8List(42)..[41] = 42);
+    mailbox.close();
+    final helperResult = startHelperIsolateClose(mailbox.asSendable);
+    expect(await helperResult, equals('success'));
+  });
 }


### PR DESCRIPTION
This is an alternative solution to the same problem described in #25 for https://github.com/sass/dart-sass/pull/2279

On high level we have following logic in dart-sass, and we need a way to reliable stop the loop via mailbox:

Main Isolate:
``` dart
isolate.kill();
try {
  mailbox.put(Uint8List(0));
} on StateError catch (_) {
  // When delivery of empty message fails due to existing message, the shutdown might lockup.
}
```

Worker Isolate:
``` dart
do {
  Uint8List data = mailbox.take();
  if (data.isEmpty) {
    break;
  }
  // do work with data
} while (true);
```

First, `Isolate.kill(priority: Isolate.immediate)` won't work when `mailbox.take()` is blocking. So, instead we call `Isolate.kill()` first, and then send an empty message to signal the stopping. However, because the sending of empty message can fail, and then depending on the event loop timing, the worker isolate may process the isolate kill event before entering the loop one more time, which works as expected (killed before next iteration of loop); or it may get to the next iteration too quickly before the isolate kill event is processed, and thus cause the VM to lock up because the next `mailbox.take()` blocks the processing of kill event, causing the isolate to be appear non-responsive. 

---

Adding `close` method as designed in this PR will allow us to do:

Main Isolate:
```dart
isolate.kill();
mailbox.close();
``` 

Worker Isolate:
``` dart
do {
  Uint8List data;
  try {
    data = mailbox.take();
  } on StateError catch (_) {
    break;
  }
  // do work with data
} while (true);
```

Because `mailbox.close()` is guaranteed to deliver the signal via `StateError` on the ongoing or next `mailbox.take()`, we don't have the problem of failing to send empty message. 